### PR TITLE
Add link to external article on Atlantis in Google Cloud Run

### DIFF
--- a/content/posts/intro-atlantis.en.md
+++ b/content/posts/intro-atlantis.en.md
@@ -527,3 +527,5 @@ I guided you through the installation and configuration process using Docker Com
 - Configuring the webhook in the repository so that Atlantis is notified about new Pull Requests.
 
 Finally, we demonstrated the complete flow in action. We saw how a Pull Request with infrastructure code changes triggered an automatic `terraform plan` as a comment and, after approval, a simple `atlantis apply` was enough to execute the changes, validating our entire setup with the creation of an S3 bucket.
+
+PS: here you are an article from a brilliant guy, Bruno with a smart way to deploy Atlantins on [Google Cloud Run](https://www.runatlantis.io/blog/2025/atlantis-on-google-cloud-run)

--- a/content/posts/intro-atlantis.md
+++ b/content/posts/intro-atlantis.md
@@ -533,3 +533,5 @@ Eu guiei você através do processo de instalação e configuração usando Dock
 - Configurar o webhook no repositório para que o Atlantis seja notificado sobre novos Pull Requests.
 
 Finalmente, demonstramos o fluxo completo em ação. Vimos como um Pull Request com alterações no código de infraestrutura acionou um `terraform plan` automático como um comentário e, após a aprovação, um simples `atlantis apply` foi o suficiente para executar as mudanças, validando todo o nosso setup com a criação de um bucket S3.
+
+PS: aqui está um artigo de um cara sensacional, o Bruno, que descreve como rodar o Atlantins no [Google Cloud Run](https://www.runatlantis.io/blog/2025/atlantis-on-google-cloud-run). Vale a pena conferir!


### PR DESCRIPTION
This pull request introduces a link to an external article detailing how to run Atlantis in Google Cloud Run. This addition aims to provide users with helpful resources for setting up Atlantis in this environment.